### PR TITLE
Merge in https://github.com/99designs/iamy/pull/63 (jacob's .iamy-version thingy)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.16.23
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/aws/aws-sdk-go v1.16.23
-	github.com/blang/semver v3.5.1+incompatible
+	github.com/blang/semver/v4 v4.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.16.23 h1:MwBOBeez0XEFVh6DCc888X+nHVBCjUDLnnWXSGGWUgM=
 github.com/aws/aws-sdk-go v1.16.23/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZq
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.16.23 h1:MwBOBeez0XEFVh6DCc888X+nHVBCjUDLnnWXSGGWUgM=
 github.com/aws/aws-sdk-go v1.16.23/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/iamy.go
+++ b/iamy.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"fmt"
 	"path/filepath"
 	"regexp"
 

--- a/iamy.go
+++ b/iamy.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/blang/semver"
+	"github.com/blang/semver/v4"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/iamy.go
+++ b/iamy.go
@@ -1,14 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
-	"fmt"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
-	"reflect"
 
 	"github.com/blang/semver/v4"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -102,7 +102,7 @@ func init() {
 }
 
 func performVersionChecks() {
-	currentIAMyVersion, _ := semver.Make(strings.TrimPrefix(Version,"v"))
+	currentIAMyVersion, _ := semver.Make(strings.TrimPrefix(Version, "v"))
 	log.Printf("current versions is %s\n", currentIAMyVersion)
 
 	if _, err := os.Stat(versionFileName); !os.IsNotExist(err) {
@@ -125,7 +125,7 @@ func performVersionChecks() {
 					os.Exit(1)
 				}
 				// Pay attention to build tags as well
-				if ! reflect.DeepEqual(localDesiredVersion.Build, currentIAMyVersion.Build) {
+				if !reflect.DeepEqual(localDesiredVersion.Build, currentIAMyVersion.Build) {
 					fmt.Printf(buildVersionMismatch, currentIAMyVersion, localDesiredVersion)
 					os.Exit(1)
 				}

--- a/iamy.go
+++ b/iamy.go
@@ -5,14 +5,20 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 
+	"github.com/blang/semver"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+const versionTooOldError = `Your version of IAMy (%s) is out of date compared to what the local
+project expects. You should upgrade to %s to use this project.`
+
 var (
-	Version    string = "dev"
-	defaultDir string
-	dryRun     *bool
+	Version         string = "dev"
+	defaultDir      string
+	dryRun          *bool
+	versionFileName string = ".iamy-version"
 )
 
 type logWriter struct{ *log.Logger }
@@ -61,6 +67,8 @@ func main() {
 		log.SetOutput(ioutil.Discard)
 	}
 
+	performVersionChecks()
+
 	switch cmd {
 	case push.FullCommand():
 		PushCommand(ui, PushCommandInput{
@@ -86,4 +94,30 @@ func init() {
 		panic(err)
 	}
 	defaultDir = filepath.Clean(dir)
+}
+
+func performVersionChecks() {
+	currentIAMyVersion, _ := semver.Make(Version)
+	log.Printf("current version is %s", currentIAMyVersion)
+
+	if _, err := os.Stat(versionFileName); !os.IsNotExist(err) {
+		log.Printf("%s found", versionFileName)
+		fileBytes, _ := ioutil.ReadFile(versionFileName)
+		fileContents := string(fileBytes)
+
+		if fileContents != "" {
+			re := regexp.MustCompile(`\d\.\d+\.\d(\+\w+)?`)
+			match := re.FindStringSubmatch(fileContents)
+			localDesiredVersion, _ := semver.Make(match[0])
+			log.Printf("local project wants version %s", localDesiredVersion)
+
+			// We don't want to notify users if the `Version` is "dev" as it's not
+			// actually too old. It could be that they are running non-released
+			// versions.
+			if Version != "dev" && currentIAMyVersion.LE(localDesiredVersion) {
+				fmt.Printf(versionTooOldError, currentIAMyVersion, localDesiredVersion)
+				os.Exit(1)
+			}
+		}
+	}
 }


### PR DESCRIPTION
From the original PR:

```
With any project, eventually you get to a stage where you have
configuration defined that works on a specific version of your software.
Upgrading between versions usually requires some effort but it's rolled
out when it's needed. This becomes even more difficult working in a team
where people can have different versions of the software that you use
based on how often they like to update their systems.

To handle these scenarios, you introduce some sort of versioning that
defines what versions you want the configuration to operate with and the
users then need to meet those requirements.

This introduces a basic concept of the versioning for IAMy. The logic is
pretty straight forward.

If you find a .iamy-version file, use the version defined in it. If
not, continue on.
If the .iamy-version file contains a version number, compare it to
the local version and ensure that the version in use meets the minimum
requirements to operate. If it doesn't, inform the user of the
discrepancy and what is required.
```