### PR TITLE
New Feature: read args from config file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build
       run: make clean release

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ FLAGS=-X main.Version=$(VERSION) -s -w
 #  - select the tag version you just created
 #  - Attach the binaries from ./bin/*
 
-release: bin/iamy-linux-amd64 bin/iamy-darwin-amd64 bin/iamy-windows-386.exe
+release: bin/iamy-linux-amd64 bin/iamy-darwin-amd64 bin/iamy-windows-386.exe bin/iamy-darwin-arm64
+
+bin/iamy-darwin-arm64:
+	@mkdir -p bin
+	GOOS=darwin GOARCH=arm64 go build -o $@ -ldflags="$(FLAGS)" .
 
 bin/iamy-linux-amd64:
 	@mkdir -p bin

--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ This allows you to use an [Infrastructure as Code](https://en.wikipedia.org/wiki
 This code was originally developed by 99designs ([origin upstream](https://github.com/99designs/iamy.git)), we recognise and appreciate the enormous effort they have put into this tool.
 This particular version has been cloned to allow Envato to rapidly develop the features that are important to our use of this tool, we are following the existing semver arrangements for the repository, but we've appended a envato build tag.
 
+# Additional features
+
+Features added to this fork include:
+- .iamy-version file support, [Original PR](https://github.com/99designs/iamy/pull/63)
+- Flags to skip resources by tag (`--skip-tagged the-tag-name` and `--skip-cfn-tagged`)
+- .iamy-flags file support for default flags. Flags are appended to command line supplied flags. Example .iamy-flags file
+  contents: `--skip-tagged=iamy-ignore`.
 
 # Upcoming features
 
-The additional features we are likely to add to this version are:
-- .iamy-version file support, [Original PR](https://github.com/99designs/iamy/pull/63)  (done)
+The additional features we are likely to add to this fork are:
 - support for organizations, ous and scps
-- allow the skipping of s3 policy management (done)
-- .iamy-config file support, you can place command line flags in a file and they will be acted on as if they were passed on the command line (done)
 
 # Installation
 
@@ -78,10 +82,10 @@ Exec all aws commands? (y/N) y
 
 ## Accurate cloudformation matching
 
-By default, iamy will use a simple heuristic (does it end with an ID, eg -ABCDEF1234) to determine if a given resource is managed by cloudformation. 
+By default, iamy will use a simple heuristic (does it end with an ID, eg -ABCDEF1234) to determine if a given resource is managed by cloudformation.
 
 This behaviour is good enough for some cases, but if you want slower but more accurate matching pass `--accurate-cfn`
-to enumerate all cloudformation stacks and resources to determine exactly which resources are managed. 
+to enumerate all cloudformation stacks and resources to determine exactly which resources are managed.
 
 ## Inspiration and similar tools
 - https://github.com/percolate/iamer

--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ This particular version has been cloned to allow Envato to rapidly develop the f
 # Upcoming features
 
 The additional features we are likely to add to this version are:
-- .iamy-version file support, [Original PR](https://github.com/99designs/iamy/pull/63)
+- .iamy-version file support, [Original PR](https://github.com/99designs/iamy/pull/63)  (done)
 - support for organizations, ous and scps
-- allow the skipping of s3 policy management
+- allow the skipping of s3 policy management (done)
+- .iamy-config file support, you can place command line flags in a file and they will be acted on as if they were passed on the command line (done)
+
+# Installation
+
+brew tap envato/envato-iamy
+brew install envato/envato-iamy/iamy
+
 
 # Development Status
 

--- a/iamy.go
+++ b/iamy.go
@@ -18,6 +18,7 @@ var (
 	defaultDir      string
 	dryRun          *bool
 	versionFileName string = ".iamy-version"
+	configFileName  string = ".iamy-config"
 )
 
 type logWriter struct{ *log.Logger }
@@ -62,7 +63,16 @@ func main() {
 		Exit:   os.Exit,
 	}
 
-	cmd := kingpin.Parse()
+	args, err := kingpin.ExpandArgsFromFile(configFileName)
+	if err != nil {
+		panic(err)
+	}
+	args = append(args, os.Args...)
+
+	cmd, err := kingpin.CommandLine.Parse(args)
+	if err != nil {
+		panic(err)
+	}
 
 	if *debug {
 		ui.Debug = log.New(os.Stderr, "DEBUG ", log.LstdFlags)

--- a/iamy.go
+++ b/iamy.go
@@ -63,21 +63,18 @@ func main() {
 		Exit:   os.Exit,
 	}
 
-	var cmd string
+	args := os.Args[1:]
 	if _, err := os.Stat(configFileName); err == nil {
-		args := os.Args[1:]
 		fileArgs, err := kingpin.ExpandArgsFromFile(configFileName)
 		if err != nil {
 			panic(err)
 		}
 		args = append(args, fileArgs...)
 
-		cmd, err = kingpin.CommandLine.Parse(args)
-		if err != nil {
-			panic(err)
-		}
-	} else {
-		cmd = kingpin.Parse()
+	}
+	cmd, err := kingpin.CommandLine.Parse(args)
+	if err != nil {
+		panic(err)
 	}
 
 	if *debug {

--- a/iamy.go
+++ b/iamy.go
@@ -42,11 +42,11 @@ func main() {
 	var (
 		debug         = kingpin.Flag("debug", "Show debugging output").Bool()
 		skipCfnTagged = kingpin.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
+		skipTagged    = kingpin.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
 		pull          = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
 		pullDir       = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
 		canDelete     = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
 		lookupCfn     = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
-		skipTagged    = pull.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
 		push          = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
 		pushDir       = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
 	)

--- a/iamy.go
+++ b/iamy.go
@@ -64,13 +64,13 @@ func main() {
 	}
 
 	args := os.Args[1:]
+	var configFileArgs []string
 	if _, err := os.Stat(configFileName); err == nil {
-		fileArgs, err := kingpin.ExpandArgsFromFile(configFileName)
+		configFileArgs, err = kingpin.ExpandArgsFromFile(configFileName)
 		if err != nil {
 			panic(err)
 		}
-		args = append(args, fileArgs...)
-
+		args = append(args, configFileArgs...)
 	}
 	cmd, err := kingpin.CommandLine.Parse(args)
 	if err != nil {
@@ -81,6 +81,9 @@ func main() {
 		ui.Debug = log.New(os.Stderr, "DEBUG ", log.LstdFlags)
 		log.SetFlags(0)
 		log.SetOutput(&logWriter{ui.Debug})
+		if len(configFileArgs) > 0 {
+			ui.Debug.Printf("Found flags in %s: %s", configFileName, configFileArgs)
+		}
 	} else {
 		log.SetOutput(ioutil.Discard)
 	}

--- a/iamy.go
+++ b/iamy.go
@@ -63,15 +63,21 @@ func main() {
 		Exit:   os.Exit,
 	}
 
-	args, err := kingpin.ExpandArgsFromFile(configFileName)
-	if err != nil {
-		panic(err)
-	}
-	args = append(args, os.Args...)
+	var cmd string
+	if _, err := os.Stat(configFileName); err == nil {
+		args := os.Args[1:]
+		fileArgs, err := kingpin.ExpandArgsFromFile(configFileName)
+		if err != nil {
+			panic(err)
+		}
+		args = append(args, fileArgs...)
 
-	cmd, err := kingpin.CommandLine.Parse(args)
-	if err != nil {
-		panic(err)
+		cmd, err = kingpin.CommandLine.Parse(args)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		cmd = kingpin.Parse()
 	}
 
 	if *debug {

--- a/iamy.go
+++ b/iamy.go
@@ -18,7 +18,7 @@ var (
 	defaultDir      string
 	dryRun          *bool
 	versionFileName string = ".iamy-version"
-	configFileName  string = ".iamy-config"
+	configFileName  string = ".iamy-flags"
 )
 
 type logWriter struct{ *log.Logger }


### PR DESCRIPTION
Allow the default of command line flags via the use of a config file.
It's pretty rudimentary, but it should work okay for now.

Example `.iamy-flags` file:

```
--skip-cfn-tagged --skip-tagged iamy-ignore
```