### PR TITLE
Support max session duration for roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Features added to this fork include:
 - .iamy-flags file support for default flags. Flags are appended to command line supplied flags. Example .iamy-flags file
   contents: `--skip-tagged=iamy-ignore`.
 - `iamy fmt`, which formats files to match the result of `iamy pull`
+- Add support for specifying [MaxSessionDuration](https://aws.amazon.com/about-aws/whats-new/2018/03/longer-role-sessions/) on a role
 
 # Upcoming features
 

--- a/iamy/awsdiff.go
+++ b/iamy/awsdiff.go
@@ -3,6 +3,7 @@ package iamy
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -282,6 +283,13 @@ func (a *awsSyncCmdGenerator) updateRoles() {
 					"--policy-arn", a.to.Account.policyArnFromString(p))
 			}
 
+			// update max session duration
+			if fromRole.MaxSessionDuration != toRole.MaxSessionDuration {
+				a.cmds.Add("aws", "iam", "update-role",
+					"--role-name", toRole.Name,
+					"--max-session-duration", strconv.Itoa(toRole.MaxSessionDuration))
+			}
+
 		} else {
 			// Create role
 			args := []string{
@@ -292,6 +300,9 @@ func (a *awsSyncCmdGenerator) updateRoles() {
 			}
 			if toRole.Description != "" {
 				args = append(args, "--description", toRole.Description)
+			}
+			if toRole.MaxSessionDuration != 0 {
+				args = append(args, "--max-session-duration", strconv.Itoa(toRole.MaxSessionDuration))
 			}
 			a.cmds.Add("aws", args...)
 

--- a/iamy/awsdiff_test.go
+++ b/iamy/awsdiff_test.go
@@ -21,6 +21,9 @@ func loadDataFrom(p string) *AccountData {
 	if err != nil {
 		panic(err.Error())
 	}
+	if len(dd) < 1 {
+		return &AccountData{}
+	}
 	return &dd[0]
 }
 
@@ -32,6 +35,58 @@ func TestPolicyIsDetachedFromRoleBeforeUpdate(t *testing.T) {
 	expected := strings.Join([]string{
 		"aws iam detach-role-policy --role-name testrole --policy-arn arn:aws:iam::123:policy/test",
 		"aws iam delete-policy --policy-arn arn:aws:iam::123:policy/test",
+	}, "\n")
+	actual := awsCmds.String()
+
+	if actual != expected {
+
+		t.Errorf(`Expected:
+%v
+Actual:
+%v`, expected, actual)
+
+	}
+}
+
+func TestCreateRoleWithMaxSessionDuration(t *testing.T) {
+	localData := loadDataFrom("max-session-duration-local")
+	remoteData := loadDataFrom("max-session-duration-remote1")
+	awsCmds := AwsCliCmdsForSync(remoteData, localData)
+
+	expected := strings.Join([]string{
+		`aws iam create-role --role-name testrole --path / --assume-role-policy-document '{
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123:root"
+      },
+      "Sid": ""
+    }
+  ],
+  "Version": "2012-10-17"
+}' --max-session-duration 7200`,
+	}, "\n")
+	actual := awsCmds.String()
+
+	if actual != expected {
+
+		t.Errorf(`Expected:
+%v
+Actual:
+%v`, expected, actual)
+
+	}
+}
+
+func TestUpdateRoleWithMaxSessionDuration(t *testing.T) {
+	localData := loadDataFrom("max-session-duration-local")
+	remoteData := loadDataFrom("max-session-duration-remote2")
+	awsCmds := AwsCliCmdsForSync(remoteData, localData)
+
+	expected := strings.Join([]string{
+		"aws iam update-role --role-name testrole --max-session-duration 7200",
 	}, "\n")
 	actual := awsCmds.String()
 

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -29,9 +29,11 @@ func (c *iamClient) getRole(name string) (string, int, error) {
 	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
 	var sessionDuration int64
 	var description string
-	if resp.Role.MaxSessionDuration != nil {
+	// 3600 is the default, so let's ignore it
+	if resp.Role.MaxSessionDuration != nil && *resp.Role.MaxSessionDuration != 3600 {
 		sessionDuration = *resp.Role.MaxSessionDuration
 	}
+
 	if resp.Role.Description != nil {
 		description = *resp.Role.Description
 	}

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -25,12 +25,17 @@ func (c *iamClient) getPolicyDescription(arn string) (string, error) {
 	return "", err
 }
 
-func (c *iamClient) getRoleDescription(name string) (string, error) {
+func (c *iamClient) getRole(name string) (string, int, error) {
 	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
-	if err == nil && resp.Role != nil && resp.Role.Description != nil {
-		return *resp.Role.Description, nil
+	var sessionDuration int64
+	var description string
+	if resp.Role.MaxSessionDuration != nil {
+		sessionDuration = *resp.Role.MaxSessionDuration
 	}
-	return "", err
+	if resp.Role.Description != nil {
+		description = *resp.Role.Description
+	}
+	return description, int(sessionDuration), err
 }
 
 func (c *iamClient) MustGetSecurityCredsForUser(username string) (accessKeyIds, mfaIds []string, hasLoginProfile bool) {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -112,6 +112,7 @@ type Role struct {
 	AssumeRolePolicyDocument *PolicyDocument `json:"AssumeRolePolicyDocument"`
 	InlinePolicies           []InlinePolicy  `json:"InlinePolicies,omitempty"`
 	Policies                 []string        `json:"Policies,omitempty"`
+	MaxSessionDuration       int             `json:"MaxSessionDuration,omitempty"`
 }
 
 type InstanceProfile struct {

--- a/iamy/testdata/awsdiff/max-session-duration-local/myalias-123/iam/role/testrole.yaml
+++ b/iamy/testdata/awsdiff/max-session-duration-local/myalias-123/iam/role/testrole.yaml
@@ -1,0 +1,9 @@
+AssumeRolePolicyDocument:
+  Statement:
+  - Action: sts:AssumeRole
+    Effect: Allow
+    Principal:
+      AWS: arn:aws:iam::123:root
+    Sid: ""
+  Version: 2012-10-17
+MaxSessionDuration: 7200

--- a/iamy/testdata/awsdiff/max-session-duration-remote2/myalias-123/iam/role/testrole.yaml
+++ b/iamy/testdata/awsdiff/max-session-duration-remote2/myalias-123/iam/role/testrole.yaml
@@ -1,0 +1,8 @@
+AssumeRolePolicyDocument:
+  Statement:
+  - Action: sts:AssumeRole
+    Effect: Allow
+    Principal:
+      AWS: arn:aws:iam::123:root
+    Sid: ""
+  Version: 2012-10-17


### PR DESCRIPTION
# Context

Max session duration allows you to allow users to assign a role for longer than the default 1h

# Changes
This PR adds support by adding an additional field to IAMY roles and the necessary plumbing to make that work

# Discussion
I feel a little uncomfortable with how `marshalRoleAsync` works, by updating a pointer to a struct "owned" by another go routine. Go race condition detector doesn't detect anything, but it feels like a foot gun for later development.

```
$ go test ./... -race
ok  	github.com/envato/iamy	0.051s
ok  	github.com/envato/iamy/iamy	0.072s
```