### PR TITLE
New feature: --skip-path

### DIFF
--- a/iamy.go
+++ b/iamy.go
@@ -44,6 +44,7 @@ func main() {
 		skipCfnTagged   = kingpin.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
 		skipTagged      = kingpin.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
 		includeTagged   = kingpin.Flag("include-tagged", "Includes IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
+		skipPaths       = kingpin.Flag("skip-path", fmt.Sprintf("Skips IAM entities that have a path starting with the supplied prefixes, repeat flag for multiple prefixes")).Strings()
 		pull            = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
 		pullDir         = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
 		pullCanDelete   = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
@@ -107,6 +108,7 @@ func main() {
 			HeuristicCfnMatching: !*lookupCfn,
 			SkipTagged:           *skipTagged,
 			IncludeTagged:        *includeTagged,
+			SkipPaths:            *skipPaths,
 		})
 
 	case pull.FullCommand():
@@ -116,6 +118,7 @@ func main() {
 			HeuristicCfnMatching: !*lookupCfn,
 			SkipTagged:           *skipTagged,
 			IncludeTagged:        *includeTagged,
+			SkipPaths:            *skipPaths,
 		})
 
 	case format.FullCommand():

--- a/iamy.go
+++ b/iamy.go
@@ -40,20 +40,20 @@ const cloudformationStackNameTag = "aws:cloudformation:stack-name"
 
 func main() {
 	var (
-		debug           = kingpin.Flag("debug", "Show debugging output").Bool()
-		skipCfnTagged   = kingpin.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
-		skipTagged      = kingpin.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
-		includeTagged   = kingpin.Flag("include-tagged", "Includes IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
-		skipPaths       = kingpin.Flag("skip-path", fmt.Sprintf("Skips IAM entities that have a path starting with the supplied prefixes, repeat flag for multiple prefixes")).Strings()
-		pull            = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
-		pullDir         = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
-		pullCanDelete   = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
-		lookupCfn       = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
-		push            = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
-		pushDir         = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
-		format          = kingpin.Command("fmt", "Update YAML files to match expected format")
-		formatDir       = format.Flag("dir", "The base directory to format").Default(defaultDir).Short('d').ExistingDir()
-		formatCanDelete = format.Flag("delete", "Delete extraneous files from destination dir").Bool()
+		debug            = kingpin.Flag("debug", "Show debugging output").Bool()
+		skipCfnTagged    = kingpin.Flag("skip-cfn-tagged", fmt.Sprintf("Shorthand for --skip-tagged %s", cloudformationStackNameTag)).Bool()
+		skipTagged       = kingpin.Flag("skip-tagged", "Skips IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
+		includeTagged    = kingpin.Flag("include-tagged", "Includes IAM entities (or buckets associated with bucket policies) tagged with a given tag").Strings()
+		skipPathPrefixes = kingpin.Flag("skip-path-prefix", fmt.Sprintf("Skips IAM entities that have a path starting with the supplied prefix, repeat flag for multiple prefixes")).Strings()
+		pull             = kingpin.Command("pull", "Syncs IAM users, groups and policies from the active AWS account to files")
+		pullDir          = pull.Flag("dir", "The directory to dump yaml files to").Default(defaultDir).Short('d').String()
+		pullCanDelete    = pull.Flag("delete", "Delete extraneous files from destination dir").Bool()
+		lookupCfn        = pull.Flag("accurate-cfn", "Fetch all known resource names from cloudformation to get exact filtering").Bool()
+		push             = kingpin.Command("push", "Syncs IAM users, groups and policies from files to the active AWS account")
+		pushDir          = push.Flag("dir", "The directory to load yaml files from").Default(defaultDir).Short('d').ExistingDir()
+		format           = kingpin.Command("fmt", "Update YAML files to match expected format")
+		formatDir        = format.Flag("dir", "The base directory to format").Default(defaultDir).Short('d').ExistingDir()
+		formatCanDelete  = format.Flag("delete", "Delete extraneous files from destination dir").Bool()
 	)
 	dryRun = kingpin.Flag("dry-run", "Show what would happen, but don't prompt to do it").Bool()
 
@@ -108,7 +108,7 @@ func main() {
 			HeuristicCfnMatching: !*lookupCfn,
 			SkipTagged:           *skipTagged,
 			IncludeTagged:        *includeTagged,
-			SkipPaths:            *skipPaths,
+			SkipPathPrefixes:     *skipPathPrefixes,
 		})
 
 	case pull.FullCommand():
@@ -118,7 +118,7 @@ func main() {
 			HeuristicCfnMatching: !*lookupCfn,
 			SkipTagged:           *skipTagged,
 			IncludeTagged:        *includeTagged,
-			SkipPaths:            *skipPaths,
+			SkipPathPrefixes:     *skipPathPrefixes,
 		})
 
 	case format.FullCommand():

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -435,7 +435,7 @@ func (a *AwsFetcher) isSkippableManagedResource(cfnType CfnResourceType, resourc
 		}
 	}
 
-        if len(a.SkipPaths) > 0 {
+	if len(a.SkipPaths) > 0 {
 		for _, path := range a.SkipPaths {
 			if strings.HasPrefix(resourcePath, path) {
 				return true, fmt.Sprintf("Skipping resource %s with path %s matches %s", resourceIdentifier, resourcePath, path)

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -19,7 +19,7 @@ type AwsFetcher struct {
 	HeuristicCfnMatching                  bool
 	SkipTagged                            []string
 	IncludeTagged                         []string
-	SkipPaths                             []string
+	SkipPathPrefixes                      []string
 
 	Debug *log.Logger
 
@@ -435,8 +435,8 @@ func (a *AwsFetcher) isSkippableManagedResource(cfnType CfnResourceType, resourc
 		}
 	}
 
-	if len(a.SkipPaths) > 0 {
-		for _, path := range a.SkipPaths {
+	if len(a.SkipPathPrefixes) > 0 {
+		for _, path := range a.SkipPathPrefixes {
 			if strings.HasPrefix(resourcePath, path) {
 				return true, fmt.Sprintf("Skipping resource %s with path %s matches %s", resourceIdentifier, resourcePath, path)
 			}

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -427,19 +427,15 @@ func (a *AwsFetcher) isSkippableManagedResource(cfnType CfnResourceType, resourc
 		}
 	}
 
-	if len(a.SkipTagged) > 0 {
-		for _, tag := range a.SkipTagged {
-			if stackName, ok := tags[tag]; ok {
-				return true, fmt.Sprintf("Skipping resource %s tagged with %s in stack %s", resourceIdentifier, tag, stackName)
-			}
+	for _, tag := range a.SkipTagged {
+		if stackName, ok := tags[tag]; ok {
+			return true, fmt.Sprintf("Skipping resource %s tagged with %s in stack %s", resourceIdentifier, tag, stackName)
 		}
 	}
 
-	if len(a.SkipPathPrefixes) > 0 {
-		for _, path := range a.SkipPathPrefixes {
-			if strings.HasPrefix(resourcePath, path) {
-				return true, fmt.Sprintf("Skipping resource %s with path %s matches %s", resourceIdentifier, resourcePath, path)
-			}
+	for _, path := range a.SkipPathPrefixes {
+		if strings.HasPrefix(resourcePath, path) {
+			return true, fmt.Sprintf("Skipping resource %s with path %s matches %s", resourceIdentifier, resourcePath, path)
 		}
 	}
 

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -28,7 +28,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range skippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{},"/")
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{}, "/")
 			if skipped == false {
 				t.Errorf("expected %s to be skipped but got false", name)
 			}
@@ -42,7 +42,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range nonSkippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{},"/")
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{}, "/")
 			if skipped == true {
 				t.Errorf("expected %s to not be skipped but got true", name)
 			}
@@ -55,7 +55,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range nonSkippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{},testSkipPath)
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{}, testSkipPath)
 			if skipped == false {
 				t.Errorf("expected %s to be skipped due to path but got false", name)
 			}

--- a/iamy/aws_test.go
+++ b/iamy/aws_test.go
@@ -8,7 +8,7 @@ import (
 
 const cloudformationStackNameTag = "aws:cloudformation:stack-name"
 const includeTestTag = "iamy-include"
-const testSkipPath = "/aws-reserved/"
+const testSkipPathPrefix = "/aws-reserved/"
 
 func TestIsSkippableManagedResource(t *testing.T) {
 	skippables := []string{
@@ -23,7 +23,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 		"myalias-123/iam/instance-profile/example.yaml",
 	}
 
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{testSkipPath}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{testSkipPathPrefix}}
 
 	for _, name := range skippables {
 		t.Run(name, func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 	for _, name := range nonSkippables {
 		t.Run(name, func(t *testing.T) {
 
-			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{}, testSkipPath)
+			skipped, err := f.isSkippableManagedResource(CfnIamRole, name, map[string]string{}, testSkipPathPrefix)
 			if skipped == false {
 				t.Errorf("expected %s to be skipped due to path but got false", name)
 			}
@@ -68,7 +68,7 @@ func TestIsSkippableManagedResource(t *testing.T) {
 }
 
 func TestSkippableS3TaggedResources(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	skippableTags := map[string]string{cloudformationStackNameTag: "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags, "NOSKIP")
@@ -81,7 +81,7 @@ func TestSkippableS3TaggedResources(t *testing.T) {
 }
 
 func TestSkippableS3TaggedResources_WithNoSkipTags(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	skippableTags := map[string]string{cloudformationStackNameTag: "my-stack"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", skippableTags, "NOSKIP")
@@ -94,7 +94,7 @@ func TestSkippableS3TaggedResources_WithNoSkipTags(t *testing.T) {
 }
 
 func TestNonSkippableTaggedResources(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	nonSkippableTags := map[string]string{"Name": "blah"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", nonSkippableTags, "NOSKIP")
@@ -107,7 +107,7 @@ func TestNonSkippableTaggedResources(t *testing.T) {
 }
 
 func TestIncludeTagsOverrideSkip(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	TestTags := map[string]string{includeTestTag: "true"}
 
 	skipped, err := f.isSkippableManagedResource(CfnS3Bucket, "my-bucket", TestTags, "NOSKIP")
@@ -128,7 +128,7 @@ func TestIncludeTagsOverrideSkip(t *testing.T) {
 }
 
 func TestSkippableIAMUserResource(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	key := cloudformationStackNameTag
 	val := "my-stack"
 	userName := "my-user"
@@ -147,7 +147,7 @@ func TestSkippableIAMUserResource(t *testing.T) {
 }
 
 func TestSkippableIAMUserResource_WithNoSkipTags(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	key := cloudformationStackNameTag
 	val := "my-stack"
 	userName := "my-user"
@@ -171,7 +171,7 @@ func TestSkippableIAMUserResource_WithNoSkipTags(t *testing.T) {
 }
 
 func TestSkippableIAMRoleResource(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{cloudformationStackNameTag}, IncludeTagged: []string{includeTestTag}, SkipPathPrefixes: []string{}}
 	key := cloudformationStackNameTag
 	val := "my-stack"
 	roleName := "my-role"
@@ -190,7 +190,7 @@ func TestSkippableIAMRoleResource(t *testing.T) {
 }
 
 func TestSkippableIAMRoleResource_WithNoSkipTags(t *testing.T) {
-	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipFetchingPolicyAndRoleDescriptions: true, SkipPaths: []string{}}
+	f := AwsFetcher{cfn: &cfnClient{}, SkipTagged: []string{}, IncludeTagged: []string{includeTestTag}, SkipFetchingPolicyAndRoleDescriptions: true, SkipPathPrefixes: []string{}}
 	key := cloudformationStackNameTag
 	val := "my-stack"
 	roleName := "my-role"

--- a/pull.go
+++ b/pull.go
@@ -12,7 +12,7 @@ type PullCommandInput struct {
 	HeuristicCfnMatching bool
 	SkipTagged           []string
 	IncludeTagged        []string
-	SkipPaths            []string
+	SkipPathPrefixes     []string
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
@@ -21,7 +21,7 @@ func PullCommand(ui Ui, input PullCommandInput) {
 		HeuristicCfnMatching: input.HeuristicCfnMatching,
 		SkipTagged:           input.SkipTagged,
 		IncludeTagged:        input.IncludeTagged,
-		SkipPaths:            input.SkipPaths,
+		SkipPathPrefixes:     input.SkipPathPrefixes,
 	}
 	data, err := aws.Fetch()
 	if err != nil {

--- a/pull.go
+++ b/pull.go
@@ -12,10 +12,17 @@ type PullCommandInput struct {
 	HeuristicCfnMatching bool
 	SkipTagged           []string
 	IncludeTagged        []string
+	SkipPaths            []string
 }
 
 func PullCommand(ui Ui, input PullCommandInput) {
-	aws := iamy.AwsFetcher{Debug: ui.Debug, HeuristicCfnMatching: input.HeuristicCfnMatching, SkipTagged: input.SkipTagged, IncludeTagged: input.IncludeTagged}
+	aws := iamy.AwsFetcher{
+		Debug:                ui.Debug,
+		HeuristicCfnMatching: input.HeuristicCfnMatching,
+		SkipTagged:           input.SkipTagged,
+		IncludeTagged:        input.IncludeTagged,
+		SkipPaths:            input.SkipPaths,
+	}
 	data, err := aws.Fetch()
 	if err != nil {
 		ui.Error.Fatal(fmt.Printf("%s", err))

--- a/push.go
+++ b/push.go
@@ -16,6 +16,7 @@ type PushCommandInput struct {
 	HeuristicCfnMatching bool
 	SkipTagged           []string
 	IncludeTagged        []string
+	SkipPaths            []string
 }
 
 func PushCommand(ui Ui, input PushCommandInput) {
@@ -28,6 +29,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 		HeuristicCfnMatching:                  input.HeuristicCfnMatching,
 		SkipTagged:                            input.SkipTagged,
 		IncludeTagged:                         input.IncludeTagged,
+		SkipPaths:                             input.SkipPaths,
 	}
 
 	allDataFromYaml, err := yaml.Load()

--- a/push.go
+++ b/push.go
@@ -16,7 +16,7 @@ type PushCommandInput struct {
 	HeuristicCfnMatching bool
 	SkipTagged           []string
 	IncludeTagged        []string
-	SkipPaths            []string
+	SkipPathPrefixes     []string
 }
 
 func PushCommand(ui Ui, input PushCommandInput) {
@@ -29,7 +29,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 		HeuristicCfnMatching:                  input.HeuristicCfnMatching,
 		SkipTagged:                            input.SkipTagged,
 		IncludeTagged:                         input.IncludeTagged,
-		SkipPaths:                             input.SkipPaths,
+		SkipPathPrefixes:                      input.SkipPathPrefixes,
 	}
 
 	allDataFromYaml, err := yaml.Load()


### PR DESCRIPTION
Whilst monkeying about with AWS SSO we discovered it creates roles and
doesn't tag them with anything that we can use to discriminate on with existing
iamy skip functionality.  It does however use a path of `/aws-reserved/`
for all of it's autogenerated roles.

This PR adds the new flag --skip-path and will exclude from consideration
any resource that has a path that starts with any of the specified unwanted 
paths.

This will let us ignore the AWS SSO created roles if we want to.

I've added a test for this that I think is sufficient, but I'm interested
to know if folks think we need to add all of the edge cases to make sure
that strings.HasPrefix is working correctly.

The other question I had was is adding to the isSkippableManagedResource
function the right approach?  Perhaps splitting into a isSkippablePath,
isSkippableTag and isSkippableResourceName function and making the top 
level function just a wrapper would be easier to test deeply?  I'm
not convinced it is worth it, but love some feedback...