### PR TITLE
Enable fetching role descriptions

### DIFF
--- a/push.go
+++ b/push.go
@@ -24,7 +24,7 @@ func PushCommand(ui Ui, input PushCommandInput) {
 		Dir: input.Dir,
 	}
 	aws := iamy.AwsFetcher{
-		SkipFetchingPolicyAndRoleDescriptions: true,
+		SkipFetchingPolicyAndRoleDescriptions: false,
 		Debug:                                 ui.Debug,
 		HeuristicCfnMatching:                  input.HeuristicCfnMatching,
 		SkipTagged:                            input.SkipTagged,


### PR DESCRIPTION
Role session durations are not returned by the GetAccountAuthorizationDetails
call, they are fetched later in the populateIamData function if
SkipFetchingPolicyAndRoleDescriptions is false.

This is a quick fix, given we always (both pull and push) need to fetch the
MaxSessionDuration attribute we should really remove all of the plumbing for
the skipping.