### PR TITLE
Fix rebuilding using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export GO111MODULE=on
 VERSION="$(shell git describe --tags --candidates=1 --dirty)+envato"
 FLAGS=-X main.Version=$(VERSION) -s -w
+SOURCES=$(wildcard *.go iamy/*.go)
 
 # To create a new release:
 #  $ git tag vx.x.x
@@ -14,25 +15,27 @@ FLAGS=-X main.Version=$(VERSION) -s -w
 
 release: bin/iamy-linux-amd64 bin/iamy-darwin-amd64 bin/iamy-windows-386.exe bin/iamy-darwin-arm64 bin/iamy-freebsd-amd64
 
-bin/iamy-darwin-arm64:
+bin/iamy-darwin-arm64: $(SOURCES)
 	@mkdir -p bin
 	GOOS=darwin GOARCH=arm64 go build -o $@ -ldflags="$(FLAGS)" .
 
-bin/iamy-linux-amd64:
+bin/iamy-linux-amd64: $(SOURCES)
 	@mkdir -p bin
 	GOOS=linux GOARCH=amd64 go build -o $@ -ldflags="$(FLAGS)" .
 
-bin/iamy-darwin-amd64:
+bin/iamy-darwin-amd64: $(SOURCES)
 	@mkdir -p bin
 	GOOS=darwin GOARCH=amd64 go build -o $@ -ldflags="$(FLAGS)" .
 
-bin/iamy-windows-386.exe:
+bin/iamy-windows-386.exe: $(SOURCES)
 	@mkdir -p bin
 	GOOS=windows GOARCH=386 go build -o $@ -ldflags="$(FLAGS)" .
 
-bin/iamy-freebsd-amd64:
+bin/iamy-freebsd-amd64: $(SOURCES)
 	@mkdir -p bin
 	GOOS=freebsd GOARCH=amd64 go build -o $@ -ldflags="$(FLAGS)" .
 
 clean:
 	rm -f bin/*
+
+.PHONY: clean release


### PR DESCRIPTION
Without dependency on sources, the build assumes that there's never a need to
rebuild the binary once it's present.
Fix that and add phony targets.