### PR TITLE
Add linux-arm64 build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,15 @@ SOURCES=$(wildcard *.go iamy/*.go)
 #  - select the tag version you just created
 #  - Attach the binaries from ./bin/*
 
-release: bin/iamy-linux-amd64 bin/iamy-darwin-amd64 bin/iamy-windows-386.exe bin/iamy-darwin-arm64 bin/iamy-freebsd-amd64
+release: bin/iamy-linux-arm64 bin/iamy-linux-amd64 bin/iamy-darwin-amd64 bin/iamy-windows-386.exe bin/iamy-darwin-arm64 bin/iamy-freebsd-amd64
 
 bin/iamy-darwin-arm64: $(SOURCES)
 	@mkdir -p bin
 	GOOS=darwin GOARCH=arm64 go build -o $@ -ldflags="$(FLAGS)" .
+
+bin/iamy-linux-arm64: $(SOURCES)
+	@mkdir -p bin
+	GOOS=linux GOARCH=arm64 go build -o $@ -ldflags="$(FLAGS)" .
 
 bin/iamy-linux-amd64: $(SOURCES)
 	@mkdir -p bin


### PR DESCRIPTION
### Context

It'd be great to target ARM64 based architectures so we can use [AWS Graviton](https://aws.amazon.com/ec2/graviton/) in our IAM drift detection checks.

### Change

Add a `linux-arm64` build target.