### PR TITLE
Ignoring errors is a bad idea

### DIFF
--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -39,6 +39,9 @@ func (c *iamClient) getPolicyTags(arn string) (map[string]string, error) {
 
 func (c *iamClient) getRole(name string) (string, int, error) {
 	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
+	if err != nil {
+		panic(err)
+	}
 	var sessionDuration int64
 	var description string
 	// 3600 is the default, so let's ignore it


### PR DESCRIPTION
This error didn't surface very often as it required the GetRole call to fail.
The "normal" reason a GetRole fails is permission denied, which doesn't much happen in our context as folks run iamy using a privileged role.
Less common are network faults, like the one Bing experienced.   Ignoring the error lead to an attempt to use memory that hadn't been allocated, with predictable consequences.

I've chosen to just panic if the role can't be retrieved as it means we don't have any information about that role and we don't want to save to disk or sync an incomplete state.    We could theoretically add retry and backoff logic to the GetRole call and see this error occur less, but in the case of a PermissionDenied it doesn't matter how many times we retry, we're never going to get the information we need.