### PR TITLE
Work around the resourcegroupsapi being broken if called outside us-east-1

### DIFF
--- a/iamy/resourcegroupstagging.go
+++ b/iamy/resourcegroupstagging.go
@@ -3,7 +3,7 @@ package iamy
 import (
 	"log"
 
-        "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
@@ -14,7 +14,7 @@ type resourceGroupsTaggingAPIClient struct {
 }
 
 func newResourceGroupsTaggingAPIClient(sess *session.Session) *resourceGroupsTaggingAPIClient {
-        // Force us of us-east-1 otherwise tags will not be returned for global resources
+	// Force us of us-east-1 otherwise tags will not be returned for global resources
 	return &resourceGroupsTaggingAPIClient{
 		resourcegroupstaggingapi.New(sess, aws.NewConfig().WithRegion("us-east-1")),
 	}

--- a/iamy/resourcegroupstagging.go
+++ b/iamy/resourcegroupstagging.go
@@ -3,6 +3,7 @@ package iamy
 import (
 	"log"
 
+        "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
@@ -13,8 +14,9 @@ type resourceGroupsTaggingAPIClient struct {
 }
 
 func newResourceGroupsTaggingAPIClient(sess *session.Session) *resourceGroupsTaggingAPIClient {
+        // Force us of us-east-1 otherwise tags will not be returned for global resources
 	return &resourceGroupsTaggingAPIClient{
-		resourcegroupstaggingapi.New(sess),
+		resourcegroupstaggingapi.New(sess, aws.NewConfig().WithRegion("us-east-1")),
 	}
 }
 


### PR DESCRIPTION
We use the resourcegroupstaggingapi to efficiently fetch tagging information for policies, sadly it returns incorrect information when used outside of the us-east-1 for global resources like IAM policies.  This is expected behaviour [according to AWS support](https://console.aws.amazon.com/support/home#/case/?displayId=10718436021&language=en) (this link only works in the customer-staging account).


You can test this for yourself by running something like this in an account you have access to:
```
% aws resourcegroupstaggingapi get-resources --resource-arn-list arn:aws:iam::<ACCOUNTNUMBER>:policy/SSO-Glue-Read-Only --region us-east-1
{
    "ResourceTagMappingList": [
        {
            "ResourceARN": "arn:aws:iam::090413119358:policy/SSO-Glue-Read-Only",
            "Tags": [
                {
                    "Key": "iamy-ignore",
                    "Value": "true"
                }
            ]
        }
    ]
}
% aws resourcegroupstaggingapi get-resources --resource-arn-list arn:aws:iam::<ACCOUNTNUMBER>:policy/SSO-Glue-Read-Only --region eu-west-1
{
    "ResourceTagMappingList": []
}
```

So this PR forces the use of us-east-1 for the resourcegroupstaggingapi, ignoring whatever config file or environment variable settings the user has.