### PR TITLE
Add support for InstanceProfile tags

### DIFF
--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -200,16 +200,6 @@ func (a *AwsFetcher) marshalPolicyDescriptionAsync(policyArn string, target *str
 	}()
 }
 
-func (a *AwsFetcher) fetchPolicyTags(policyArn string, tags *map[string]string) {
-	log.Println("Fetching tags for", policyArn)
-
-	var err error
-	*tags, err = a.iam.getPolicyTags(policyArn)
-	if err != nil {
-		a.policyTagFetchError = err
-	}
-}
-
 func (a *AwsFetcher) fetchInstanceProfileTags(instanceProfileName string, tags *map[string]string) {
 	log.Println("Fetching tags for instance profile ", instanceProfileName)
 

--- a/iamy/aws.go
+++ b/iamy/aws.go
@@ -210,6 +210,16 @@ func (a *AwsFetcher) fetchPolicyTags(policyArn string, tags *map[string]string) 
 	}
 }
 
+func (a *AwsFetcher) fetchInstanceProfileTags(instanceProfileName string, tags *map[string]string) {
+	log.Println("Fetching tags for instance profile ", instanceProfileName)
+
+	var err error
+	*tags, err = a.iam.getInstanceProfileTags(instanceProfileName)
+	if err != nil {
+		a.policyTagFetchError = err
+	}
+}
+
 func (a *AwsFetcher) marshalRoleAsync(roleName string, roleDescription *string, roleMaxSessionDuration *int) {
 	a.descriptionFetchWaitGroup.Add(1)
 	go func() {
@@ -230,7 +240,10 @@ func (a *AwsFetcher) marshalRoleAsync(roleName string, roleDescription *string, 
 
 func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesOutput) error {
 	for _, profileResp := range resp.InstanceProfiles {
-		if ok, err := a.isSkippableManagedResource(CfnInstanceProfile, *profileResp.InstanceProfileName, map[string]string{}, *profileResp.Path); ok {
+		tags := make(map[string]string)
+		a.fetchInstanceProfileTags(*profileResp.InstanceProfileName, &tags)
+
+		if ok, err := a.isSkippableManagedResource(CfnInstanceProfile, *profileResp.InstanceProfileName, tags, *profileResp.Path); ok {
 			log.Printf(err)
 			continue
 		}
@@ -243,6 +256,7 @@ func (a *AwsFetcher) populateInstanceProfileData(resp *iam.ListInstanceProfilesO
 			role := *(roleResp.RoleName)
 			profile.Roles = append(profile.Roles, role)
 		}
+		profile.Tags = tags
 		a.data.InstanceProfiles = append(a.data.InstanceProfiles, &profile)
 	}
 	return nil

--- a/iamy/iam.go
+++ b/iamy/iam.go
@@ -37,6 +37,18 @@ func (c *iamClient) getPolicyTags(arn string) (map[string]string, error) {
 	return nil, err
 }
 
+func (c *iamClient) getInstanceProfileTags(name string) (map[string]string, error) {
+	resp, err := c.ListInstanceProfileTags(&iam.ListInstanceProfileTagsInput{InstanceProfileName: &name})
+	if err == nil && resp.Tags != nil {
+		tags := make(map[string]string)
+		for _, tag := range resp.Tags {
+			tags[*tag.Key] = *tag.Value
+		}
+		return tags, err
+	}
+	return nil, err
+}
+
 func (c *iamClient) getRole(name string) (string, int, error) {
 	resp, err := c.GetRole(&iam.GetRoleInput{RoleName: &name})
 	if err != nil {

--- a/iamy/models.go
+++ b/iamy/models.go
@@ -119,6 +119,7 @@ type Role struct {
 type InstanceProfile struct {
 	iamService `json:"-"`
 	Roles      []string `json:"Roles,omitempty"`
+	Tags       map[string]string `json:"Tags,omitempty"`
 }
 
 func (ip InstanceProfile) ResourceType() string {


### PR DESCRIPTION
InstanceProfile tags have a separate API call. To be able to ignore them, we need to pull their tags.
This initially came from an annoyance where some resources like instance profiles use a mix of lower- and upper-case in the cloudformation names and cannot be skipped automatically with the existing code.