### PR TITLE
Update the cfn resource regexp

### DIFF
--- a/iamy/cfn.go
+++ b/iamy/cfn.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 )
 
-var cfnResourceRegexp = regexp.MustCompile(`-[A-Z0-9]{10,20}$`)
+var cfnResourceRegexp = regexp.MustCompile(`-[A-Za-z0-9]{10,20}$`)
 
 type CfnResourceType string
 

--- a/iamy/cfn_test.go
+++ b/iamy/cfn_test.go
@@ -30,6 +30,9 @@ func TestCfnMangedResources(t *testing.T) {
 		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-ABCDEFGH1234567") {
 			t.Fatal("names with id suffix are managed")
 		}
+		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-ABCDEFabcde12345") {
+			t.Fatal("names with id suffix are managed")
+		}
 
 		if cfn.IsManagedResource(CfnIamPolicy, "foobar-abcdefgh1234567") {
 			t.Fatal("names with suffix containing only lowercase letters are not managed")

--- a/iamy/cfn_test.go
+++ b/iamy/cfn_test.go
@@ -33,10 +33,10 @@ func TestCfnMangedResources(t *testing.T) {
 		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-ABCDEFabcde12345") {
 			t.Fatal("names with id suffix are managed")
 		}
-		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-Production") {
+		
+		if cfn.IsManagedResource(CfnIamPolicy, "foobar-Production") {
 			t.Fatal("names with id suffix are managed")
 		}
-
 		if cfn.IsManagedResource(CfnIamPolicy, "foobar-abcdefgh1234567") {
 			t.Fatal("names with suffix containing only lowercase letters are not managed")
 		}

--- a/iamy/cfn_test.go
+++ b/iamy/cfn_test.go
@@ -33,6 +33,9 @@ func TestCfnMangedResources(t *testing.T) {
 		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-ABCDEFabcde12345") {
 			t.Fatal("names with id suffix are managed")
 		}
+		if !cfn.IsManagedResource(CfnIamPolicy, "foobar-Production") {
+			t.Fatal("names with id suffix are managed")
+		}
 
 		if cfn.IsManagedResource(CfnIamPolicy, "foobar-abcdefgh1234567") {
 			t.Fatal("names with suffix containing only lowercase letters are not managed")


### PR DESCRIPTION
# Context

Currently this instance profile doesn't ignore from iam pull

`arn:aws:iam::738896855197:instance-profile/elements-staging-buildkite-x86-a-IAMInstanceProfile-pMSAYRATayaX`